### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/src/providers/srt.py
+++ b/src/providers/srt.py
@@ -728,9 +728,7 @@ class SRT:
         self.membership_name = user_info["CUST_NM"]
         self.phone_number = user_info["MBL_PHONE"]
 
-        print(
-            f"로그인 성공: {self.membership_name} (멤버십번호: {self.membership_number}, 전화번호: {self.phone_number})"
-        )
+        print("로그인 성공")
         return True
 
     def logout(self) -> bool:


### PR DESCRIPTION
Potential fix for [https://github.com/zits93/skimbleshanks/security/code-scanning/4](https://github.com/zits93/skimbleshanks/security/code-scanning/4)

General fix: never print raw PII (name, membership number, phone number). If success feedback is needed, log a generic message or masked values only.

Best fix here (without changing core functionality): replace the current success `print` with a non-sensitive success message. This preserves behavior (login still succeeds and reports success) while eliminating sensitive disclosure.

Change needed in `src/providers/srt.py`:
- In `login()` around lines 731–733, replace the f-string containing `self.membership_name`, `self.membership_number`, and `self.phone_number` with a static message like `"로그인 성공"`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
