### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   python-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zits93/skimbleshanks/security/code-scanning/1](https://github.com/zits93/skimbleshanks/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix without changing functionality: set:

- `contents: read`

This is sufficient for `actions/checkout` and for the shown test/build steps. Place the block after the trigger section (`on:`...) and before `jobs:` so it applies workflow-wide.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
