### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -232,8 +232,8 @@ async def reserve_train(req: ReserveRequest):
 
         return {"success": False, "message": "Seat not available.", "retry": True}
     except Exception as e:
-        logger.error(f"Reservation error: {str(e)}")
-        return {"success": False, "message": str(e), "retry": True}
+        logger.exception("Reservation error")
+        return {"success": False, "message": "An internal error occurred.", "retry": True}
 
 # Serve frontend static files if they exist
 if os.path.exists("frontend/dist"):


### PR DESCRIPTION
Potential fix for [https://github.com/zits93/skimbleshanks/security/code-scanning/3](https://github.com/zits93/skimbleshanks/security/code-scanning/3)

To fix this without changing functionality, keep the existing catch/log behavior but stop returning `str(e)` to the client. Instead:

- Log the exception on the server with traceback context (`logger.exception(...)`), so developers keep diagnostics.
- Return a generic error message in the API response (for example, `"An internal error occurred."`) and keep existing fields like `success` and `retry`.

**Where to change:** `src/api/app.py`, inside `reserve_train`, in the `except Exception as e:` block around lines 234–236.

**Implementation details:**
- Replace `logger.error(f"Reservation error: {str(e)}")` with `logger.exception("Reservation error")`.
- Replace `return {"success": False, "message": str(e), "retry": True}` with a generic message return.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
