### PR TITLE
[IMPROVE] 프론트엔드 API Key 하드코딩 및 민감 정보 전송 방식 개선

### DIFF
--- a/frontend/src/features/api-settings/ui/CardSettings.tsx
+++ b/frontend/src/features/api-settings/ui/CardSettings.tsx
@@ -4,7 +4,7 @@ import { useRailStore } from '../../reservation/model/railStore';
 export function CardSettings() {
     const { 
         cardNum, cardPw, cardBirth, cardExp,
-        setCardField 
+        setCardField, saveCardInfo 
     } = useRailStore();
 
     return (
@@ -13,21 +13,27 @@ export function CardSettings() {
                 <CreditCard size={20} /> 자동 결제 카드 정보
             </h3>
             <p style={{fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem', lineHeight: '1.5'}}>
-                정보를 입력하면 예매 성공 시 즉시 결제가 진행됩니다. <br/>
+                정보를 입력하고 <b>서버 저장</b> 버튼을 누르면 예매 성공 시 즉시 결제가 진행됩니다. <br/>
                 결제 실패 시 예매가 취소될 수 있으니 정확한 정보를 입력해주세요.
-                <div style={{ fontSize: '0.75rem', opacity: 0.5, marginTop: '1.2rem', textAlign: 'center', lineHeight: 1.4 }}>
-                    🔒 입력하신 카드 정보는 브라우저에만 저장되며,<br/>서버 데이터베이스에는 저장되지 않습니다.
-                </div>
             </p>
             
             <div className="input-group">
                 <label>카드 번호</label>
                 <input type="text" value={cardNum} onChange={e => setCardField('cardNum', e.target.value)} placeholder="0000-0000-0000-0000" />
             </div>
-            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '1rem'}}>
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '1rem', marginBottom: '1.5rem'}}>
                 <div className="input-group"><label>비밀번호 (앞2자리)</label><input type="password" value={cardPw} onChange={e => setCardField('cardPw', e.target.value)} placeholder="**" maxLength={2} /></div>
                 <div className="input-group"><label>생년월일 (6자리)</label><input type="text" value={cardBirth} onChange={e => setCardField('cardBirth', e.target.value)} placeholder="YYMMDD" maxLength={6} /></div>
                 <div className="input-group"><label>만료일 (YYMM)</label><input type="text" value={cardExp} onChange={e => setCardField('cardExp', e.target.value)} placeholder="YYMM" maxLength={4} /></div>
+            </div>
+
+            <button className="btn-primary" onClick={saveCardInfo} style={{ width: '100%' }}>
+                서버에 안전하게 저장
+            </button>
+
+            <div style={{ fontSize: '0.75rem', opacity: 0.6, marginTop: '1.2rem', textAlign: 'center', lineHeight: 1.4 }}>
+                🔒 입력하신 정보는 서버의 안전한 저장소(Keyring)에 보관되며,<br/>
+                조회 및 예매 시에만 사용됩니다.
             </div>
         </div>
     );

--- a/frontend/src/features/reservation/model/railStore.ts
+++ b/frontend/src/features/reservation/model/railStore.ts
@@ -30,6 +30,7 @@ interface RailStore {
     // Setters
     setSearchField: (field: string, value: any) => void;
     setCardField: (field: string, value: any) => void;
+    saveCardInfo: () => Promise<void>;
     toggleTarget: (trainName: string, seatType: string) => void;
     bulkToggleTarget: (seatType: string) => void;
     
@@ -64,11 +65,24 @@ export const useRailStore = create<RailStore>((set, get) => ({
     cardExp: localStorage.getItem('skimbleshanks_card_exp') || '',
 
     setSearchField: (field, value) => set({ [field]: value } as any),
-    setCardField: (field, value) => {
-        set({ [field]: value } as any);
-        if (field.startsWith('card')) {
-            const storageKey = `skimbleshanks_${field.replace(/[A-Z]/g, (l) => `_${l.toLowerCase()}`)}`;
-            localStorage.setItem(storageKey, value);
+    setCardField: (field, value) => set({ [field]: value } as any),
+    
+    saveCardInfo: async () => {
+        const { cardNum, cardPw, cardBirth, cardExp } = get();
+        const { showToast } = useUiStore.getState();
+        try {
+            await apiFetch('/config/card', {
+                method: 'POST',
+                body: JSON.stringify({ 
+                    number: cardNum, 
+                    password: cardPw, 
+                    birthday: cardBirth, 
+                    expire: cardExp 
+                })
+            });
+            showToast('카드 정보가 서버에 안전하게 저장되었습니다.', 'success');
+        } catch (e: any) {
+            showToast(e.message || '카드 정보 저장 실패', 'error');
         }
     },
 
@@ -151,11 +165,8 @@ export const useRailStore = create<RailStore>((set, get) => ({
                         adults: state.adults, children: state.children, seniors: state.seniors,
                         disability1to3: state.dis1to3, disability4to6: state.dis4to6,
                         targets: state.selectedTargets, auto_pay: true,
-                        card_number: state.cardNum, 
-                        card_password: state.cardPw,
-                        card_birthday: state.cardBirth, 
-                        card_expire: state.cardExp,
                         provider: 'SRT'
+                        // card info is now pulled from backend config_store preferentially
                     })
                 });
 

--- a/frontend/src/shared/api/api.ts
+++ b/frontend/src/shared/api/api.ts
@@ -17,7 +17,7 @@ const getApiBase = () => {
 };
 
 const API_BASE = getApiBase();
-const API_KEY = localStorage.getItem('skimbleshanks_api_key') || 'your-secret-key';
+const API_KEY = localStorage.getItem('skimbleshanks_api_key') || '';
 
 export async function apiFetch(endpoint: string, options: RequestInit = {}): Promise<Response> {
     const headers = {

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -66,6 +66,12 @@ class TelegramRequest(BaseModel):
     token: str
     chat_id: str
 
+class CardConfigRequest(BaseModel):
+    number: str
+    password: str
+    birthday: str
+    expire: str
+
 @app.post("/api/telegram", dependencies=[Depends(verify_api_key)])
 async def set_telegram(req: TelegramRequest):
     from src.services.notifications import configure_telegram
@@ -76,6 +82,23 @@ async def set_telegram(req: TelegramRequest):
         raise HTTPException(
             status_code=400, 
             detail={"code": "ERR_TELEGRAM_CONFIG_FAILED", "message": "Failed to configure Telegram"}
+        )
+
+@app.post("/api/config/card", dependencies=[Depends(verify_api_key)])
+async def save_card_config(req: CardConfigRequest):
+    try:
+        config_store.save_card({
+            "number": req.number,
+            "password": req.password,
+            "birthday": req.birthday,
+            "expire": req.expire
+        })
+        return {"message": "Card configuration saved successfully"}
+    except Exception as e:
+        logger.error(f"Failed to save card config: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail={"code": "ERR_SAVE_CONFIG_FAILED", "message": "카드 정보 저장에 실패했습니다."}
         )
 
 class ReserveTarget(BaseModel):
@@ -225,18 +248,26 @@ async def reserve_train(req: ReserveRequest):
                 logger.info(msg)
 
                 if req.auto_pay and not getattr(reserve_info, 'is_waiting', False):
-                    if req.card_number and req.card_password and req.card_birthday and req.card_expire:
+                    # Prefer stored card info from config_store
+                    card_info = config_store.get_card_payment_info()
+                    
+                    # If not in store, use from request (if provided)
+                    c_num = card_info[0] if card_info else req.card_number.get_secret_value()
+                    c_pw = card_info[1] if card_info else req.card_password.get_secret_value()
+                    c_birth = card_info[2] if card_info else req.card_birthday
+                    c_exp = card_info[3] if card_info else req.card_expire.get_secret_value()
+
+                    if c_num and c_pw and c_birth and c_exp:
                         logger.info(f"Attempting auto-payment for {reserve_info}")
-                        birthday = req.card_birthday
                         paid = await run_in_threadpool(
                             rail.pay_with_card,
                             reserve_info,
-                            req.card_number.get_secret_value(),
-                            req.card_password.get_secret_value(),
-                            birthday,
-                            req.card_expire.get_secret_value(),
+                            c_num,
+                            c_pw,
+                            c_birth,
+                            c_exp,
                             0,
-                            "J" if len(birthday) == 6 else "S",
+                            "J" if len(c_birth) == 6 else "S",
                         )
                         if paid:
                             msg += " (결제 완료)"


### PR DESCRIPTION
이 PR은 이슈 #10을 해결합니다.
- 서버 측 카드 정보 안전 저장 API 추가 (Keyring 사용)
- 예매 시 클라이언트에서 민감 정보를 매번 전송하지 않도록 개선
- 프론트엔드 기본 API Key 제거