### PR TITLE
[FEAT] 프론트엔드 통합 설정 페이지 및 로깅 고도화

### DIFF
--- a/frontend/src/features/api-settings/ui/StationSettings.tsx
+++ b/frontend/src/features/api-settings/ui/StationSettings.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useAuthStore } from '../../auth/model/authStore';
+import { MapPin, Save, Plus, X } from 'lucide-react';
+
+export function StationSettings({ provider }: { provider: 'SRT' | 'KTX' }) {
+    const { srtStations, ktxStations, setStations } = useAuthStore();
+    const currentStations = provider === 'SRT' ? srtStations : ktxStations;
+    const [newStation, setNewStation] = useState('');
+
+    const handleAdd = () => {
+        if (!newStation) return;
+        if (currentStations.includes(newStation)) return;
+        setStations(provider, [...currentStations, newStation]);
+        setNewStation('');
+    };
+
+    const handleRemove = (name: string) => {
+        setStations(provider, currentStations.filter(s => s !== name));
+    };
+
+    return (
+        <div className="glass" style={{ padding: '1.5rem' }}>
+            <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontSize: '1.1rem', color: 'var(--primary)', marginBottom: '1rem' }}>
+                <MapPin size={18} /> {provider} 선호 역 설정
+            </h3>
+            
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+                {currentStations.map(s => (
+                    <span key={s} className="badge" style={{ padding: '0.4rem 0.8rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                        {s}
+                        <button onClick={() => handleRemove(s)} style={{ background: 'none', border: 'none', color: 'inherit', cursor: 'pointer', padding: 0, display: 'flex' }}>
+                            <X size={14} />
+                        </button>
+                    </span>
+                ))}
+                {currentStations.length === 0 && <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>등록된 역이 없습니다.</div>}
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <input 
+                    type="text" 
+                    value={newStation} 
+                    onChange={e => setNewStation(e.target.value)} 
+                    placeholder="역 이름 입력 (예: 대전)"
+                    style={{ flex: 1 }}
+                    onKeyDown={e => e.key === 'Enter' && handleAdd()}
+                />
+                <button className="btn-primary" onClick={handleAdd} style={{ padding: '0.5rem 1rem' }}>
+                    <Plus size={18} />
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/auth/model/authStore.ts
+++ b/frontend/src/features/auth/model/authStore.ts
@@ -10,6 +10,17 @@ interface AuthStore {
     logout: () => void;
     checkConfig: () => Promise<void>;
     
+    // Server Config
+    srtStations: string[];
+    ktxStations: string[];
+    options: string[];
+    setStations: (provider: string, stations: string[]) => Promise<void>;
+    setOptions: (options: string[]) => Promise<void>;
+
+    // Logs
+    serverLogs: string[];
+    fetchLogs: () => Promise<void>;
+    
     // Telegram Settings
     tgToken: string;
     tgChatId: string;
@@ -26,6 +37,11 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     tgToken: '',
     tgChatId: '',
     showTgGuide: false,
+
+    srtStations: [],
+    ktxStations: [],
+    options: [],
+    serverLogs: [],
 
     setUserId: (userId) => set({ userId }),
     setTgField: (field, value) => set({ [field]: value } as any),
@@ -63,6 +79,11 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
                 if (data.srt_user_id) set({ userId: data.srt_user_id });
                 if (data.telegram_token) set({ tgToken: data.telegram_token });
                 if (data.telegram_chat_id) set({ tgChatId: data.telegram_chat_id });
+                set({
+                    srtStations: data.srt_stations || [],
+                    ktxStations: data.ktx_stations || [],
+                    options: data.options || []
+                });
             }
         } catch (e) {
             // Ignore initial config check errors
@@ -82,5 +103,34 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
             console.error('Failed to save telegram settings', e);
             showToast(e.message || '텔레그램 설정 실패', 'error');
         }
+    },
+
+    setStations: async (provider, stations) => {
+        try {
+            await apiFetch('/config/stations', {
+                method: 'POST',
+                body: JSON.stringify({ provider, stations })
+            });
+            if (provider === 'SRT') set({ srtStations: stations });
+            else set({ ktxStations: stations });
+        } catch (e) {}
+    },
+
+    setOptions: async (options) => {
+        try {
+            await apiFetch('/config/options', {
+                method: 'POST',
+                body: JSON.stringify({ options })
+            });
+            set({ options });
+        } catch (e) {}
+    },
+
+    fetchLogs: async () => {
+        try {
+            const res = await apiFetch('/logs?lines=100');
+            const data = await res.json();
+            set({ serverLogs: data.logs });
+        } catch (e) {}
     }
 }));

--- a/frontend/src/pages/main/ui/MainPage.tsx
+++ b/frontend/src/pages/main/ui/MainPage.tsx
@@ -4,7 +4,9 @@ import { SearchForm } from '../../../widgets/search-form/ui/SearchForm';
 import { TrainList } from '../../../widgets/train-list/ui/TrainList';
 import { CardSettings } from '../../../features/api-settings/ui/CardSettings';
 import { TelegramSettings } from '../../../features/api-settings/ui/TelegramSettings';
-import { Settings, Search, Terminal } from 'lucide-react';
+import { StationSettings } from '../../../features/api-settings/ui/StationSettings';
+import { LogViewer } from '../../../widgets/log-viewer/ui/LogViewer';
+import { Settings, Search, Terminal, Activity } from 'lucide-react';
 import { useUiStore } from '../../../shared/api/uiStore';
 import '../../../app/style.css';
 
@@ -19,15 +21,18 @@ export default function MainPage() {
             <div className="nav-tabs-wrapper">
                 <div className="nav-tabs">
                     <div className="active-bg" style={{
-                        width: '150px',
-                        transform: activeTab === 'search' ? 'translateX(0)' : 'translateX(150px)',
+                        width: '120px',
+                        transform: activeTab === 'search' ? 'translateX(0)' : activeTab === 'settings' ? 'translateX(120px)' : 'translateX(240px)',
                         left: '0.4rem'
                     }}></div>
-                    <button className={activeTab === 'search' ? 'active' : ''} onClick={() => setActiveTab('search')} style={{ width: '150px' }}>
+                    <button className={activeTab === 'search' ? 'active' : ''} onClick={() => setActiveTab('search')} style={{ width: '120px' }}>
                         <Search size={20} /> 예매
                     </button>
-                    <button className={activeTab === 'settings' ? 'active' : ''} onClick={() => setActiveTab('settings')} style={{ width: '150px' }}>
+                    <button className={activeTab === 'settings' ? 'active' : ''} onClick={() => setActiveTab('settings')} style={{ width: '120px' }}>
                         <Settings size={20} /> 설정
+                    </button>
+                    <button className={activeTab === 'logs' ? 'active' : ''} onClick={() => setActiveTab('logs')} style={{ width: '120px' }}>
+                        <Activity size={20} /> 로그
                     </button>
                 </div>
             </div>
@@ -44,21 +49,29 @@ export default function MainPage() {
                         <SearchForm stations={STATIONS} />
                         <TrainList />
                     </div>
-                ) : (
-                    <div style={{ maxWidth: '600px', margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-                        <CardSettings />
-                        
-                        <div className="glass" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '1rem 2rem', opacity: 0.8 }}>
-                            <span style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                                <Terminal size={16} /> 개발자 모드 (텔레그램)
-                            </span>
-                            <label className="switch">
-                                <input type="checkbox" checked={devMode} onChange={e => setDevMode(e.target.checked)} />
-                                <span className="slider round"></span>
-                            </label>
+                ) : activeTab === 'settings' ? (
+                    <div style={{ maxWidth: '800px', margin: '0 auto', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1.5rem' }}>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+                            <CardSettings />
+                            <StationSettings provider="SRT" />
                         </div>
-
-                        {devMode && <TelegramSettings />}
+                        
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+                            <div className="glass" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '1rem 2rem', opacity: 0.8 }}>
+                                <span style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--text-muted)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                                    <Terminal size={16} /> 개발자 모드 (텔레그램)
+                                </span>
+                                <label className="switch">
+                                    <input type="checkbox" checked={devMode} onChange={e => setDevMode(e.target.checked)} />
+                                    <span className="slider round"></span>
+                                </label>
+                            </div>
+                            {devMode && <TelegramSettings />}
+                        </div>
+                    </div>
+                ) : (
+                    <div style={{ maxWidth: '1000px', margin: '0 auto' }}>
+                        <LogViewer />
                     </div>
                 )}
             </motion.div>

--- a/frontend/src/widgets/log-viewer/ui/LogViewer.tsx
+++ b/frontend/src/widgets/log-viewer/ui/LogViewer.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import { useAuthStore } from '../../../features/auth/model/authStore';
+import { Terminal, RefreshCw } from 'lucide-react';
+
+export function LogViewer() {
+    const { serverLogs, fetchLogs } = useAuthStore();
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        fetchLogs();
+        const timer = setInterval(fetchLogs, 5000);
+        return () => clearInterval(timer);
+    }, [fetchLogs]);
+
+    useEffect(() => {
+        if (scrollRef.current) {
+            scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        }
+    }, [serverLogs]);
+
+    return (
+        <div className="glass" style={{ padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem', height: '400px' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <h3 style={{ display: 'flex', alignItems: 'center', gap: '0.6rem', fontSize: '1.1rem', color: 'var(--primary)', margin: 0 }}>
+                    <Terminal size={18} /> 실시간 서버 로그
+                </h3>
+                <button onClick={fetchLogs} className="icon-btn" title="새로고침">
+                    <RefreshCw size={16} />
+                </button>
+            </div>
+            
+            <div 
+                ref={scrollRef}
+                style={{ 
+                    backgroundColor: 'rgba(0,0,0,0.3)', 
+                    borderRadius: '8px', 
+                    padding: '1rem', 
+                    flex: 1, 
+                    overflowY: 'auto',
+                    fontFamily: 'monospace',
+                    fontSize: '0.8rem',
+                    lineHeight: '1.4',
+                    color: '#e0e0e0'
+                }}
+            >
+                {serverLogs.length === 0 ? (
+                    <div style={{ color: 'var(--text-muted)', textAlign: 'center', marginTop: '2rem' }}>로그가 없습니다.</div>
+                ) : (
+                    serverLogs.map((log, i) => {
+                        let color = '#e0e0e0';
+                        if (log.includes('INFO')) color = '#a0c0ff';
+                        if (log.includes('WARNING')) color = '#ffd080';
+                        if (log.includes('ERROR')) color = '#ff8080';
+                        if (log.includes('SUCCESS')) color = '#80ffb0';
+
+                        return <div key={i} style={{ color, marginBottom: '2px', wordBreak: 'break-all' }}>{log}</div>
+                    })
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -72,6 +72,13 @@ class CardConfigRequest(BaseModel):
     birthday: str
     expire: str
 
+class StationConfigRequest(BaseModel):
+    provider: str
+    stations: List[str]
+
+class OptionsConfigRequest(BaseModel):
+    options: List[str]
+
 @app.post("/api/telegram", dependencies=[Depends(verify_api_key)])
 async def set_telegram(req: TelegramRequest):
     from src.services.notifications import configure_telegram
@@ -100,6 +107,34 @@ async def save_card_config(req: CardConfigRequest):
             status_code=500,
             detail={"code": "ERR_SAVE_CONFIG_FAILED", "message": "카드 정보 저장에 실패했습니다."}
         )
+
+@app.post("/api/config/stations", dependencies=[Depends(verify_api_key)])
+async def save_stations_config(req: StationConfigRequest):
+    try:
+        config_store.save_station(req.provider, req.stations)
+        return {"message": "Station preferences saved"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/api/config/options", dependencies=[Depends(verify_api_key)])
+async def save_options_config(req: OptionsConfigRequest):
+    try:
+        config_store.set_options(req.options)
+        return {"message": "Option preferences saved"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/api/logs", dependencies=[Depends(verify_api_key)])
+async def get_logs(lines: int = 100):
+    from src.services.logger import LOG_FILE
+    if not os.path.exists(LOG_FILE):
+        return {"logs": []}
+    try:
+        with open(LOG_FILE, "r", encoding="utf-8") as f:
+            all_lines = f.readlines()
+            return {"logs": all_lines[-lines:]}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 class ReserveTarget(BaseModel):
     train_name: str
@@ -156,6 +191,9 @@ async def get_config():
         "ktx_logged_in": config_store.has_login("KTX"),
         "srt_user_id": srt_id,
         "ktx_user_id": ktx_id,
+        "srt_stations": config_store.get_station_value("SRT").split(",") if config_store.get_station_value("SRT") else [],
+        "ktx_stations": config_store.get_station_value("KTX").split(",") if config_store.get_station_value("KTX") else [],
+        "options": config_store.get_options(),
     }
 
 @app.get("/api/stations/{provider}", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
이 PR은 이슈 #8을 해결합니다.
- 서버 로그 조회 API 및 프론트엔드 로그 뷰어 위젯 추가
- 선호 역 설정 및 승객 옵션 관리 기능 통합
- 설정 대시보드 UI 개선