### PR TITLE
[FEAT] 서버 측 예매 루프 전환 및 SSE 실시간 상태 업데이트

### DIFF
--- a/frontend/src/features/reservation/model/railStore.ts
+++ b/frontend/src/features/reservation/model/railStore.ts
@@ -10,6 +10,7 @@ interface RailStore {
     autoReserveActive: boolean;
     autoReserveAttempts: number;
     searching: boolean;
+    activeTaskId: string | null;
     
     // Search Fields
     dep: string;
@@ -48,6 +49,7 @@ export const useRailStore = create<RailStore>((set, get) => ({
     autoReserveActive: false,
     autoReserveAttempts: 0,
     searching: false,
+    activeTaskId: null,
 
     dep: '수서',
     arr: '부산',
@@ -133,70 +135,80 @@ export const useRailStore = create<RailStore>((set, get) => ({
         }
     },
 
-    startAutoReserve: () => {
-        const { selectedTargets, cardNum, cardPw, cardBirth, cardExp } = get();
+    startAutoReserve: async () => {
+        const { selectedTargets } = get();
         const { showAlert } = useUiStore.getState();
         const { addLog, clearLogs } = useLogStore.getState();
 
         if (selectedTargets.length === 0) return showAlert('알림', '예매할 열차를 먼저 선택해주세요.', '⚠️');
-        if (!cardNum || !cardPw || !cardBirth || !cardExp) {
-            useUiStore.getState().setActiveTab('settings');
-            showAlert('알림', '자동 결제를 위한 카드 정보를 모두 입력해주세요.', '💳', 5000, '확인');
-            return;
-        }
 
         clearLogs();
-        addLog('자동 예매를 시작합니다.', 'info');
-        set({ autoReserveActive: true, autoReserveAttempts: 0 });
+        addLog('서버 예매 세션을 요청합니다...', 'info');
         
-        const attempt = async () => {
+        try {
             const state = get();
-            if (!state.autoReserveActive) return;
+            const res = await apiFetch('/reserve/start', {
+                method: 'POST',
+                body: JSON.stringify({
+                    dep: state.dep, arr: state.arr, date: state.date, time: state.time,
+                    adults: state.adults, children: state.children, seniors: state.seniors,
+                    disability1to3: state.dis1to3, disability4to6: state.dis4to6,
+                    targets: state.selectedTargets, auto_pay: true,
+                    provider: 'SRT'
+                })
+            });
 
-            set(s => ({ autoReserveAttempts: s.autoReserveAttempts + 1 }));
-            const currentAttempt = get().autoReserveAttempts;
-            addLog(`[${currentAttempt}회차] 열차 조회 및 예매 시도 중...`, 'info');
+            const { task_id } = await res.json();
+            set({ autoReserveActive: true, activeTaskId: task_id, autoReserveAttempts: 0 });
 
-            try {
-                const res = await apiFetch('/reserve', {
-                    method: 'POST',
-                    body: JSON.stringify({
-                        dep: state.dep, arr: state.arr, date: state.date, time: state.time,
-                        adults: state.adults, children: state.children, seniors: state.seniors,
-                        disability1to3: state.dis1to3, disability4to6: state.dis4to6,
-                        targets: state.selectedTargets, auto_pay: true,
-                        provider: 'SRT'
-                        // card info is now pulled from backend config_store preferentially
-                    })
-                });
-
-                if (!get().autoReserveActive) return;
-
-                const data = await res.json();
-                if (data.success) {
-                    addLog(`예매 성공! ${data.message}`, 'success');
-                    set({ autoReserveActive: false });
-                    showAlert('🎉 예매 성공!', data.message, '🎊');
-                } else if (data.retry) {
-                    autoTimer = setTimeout(attempt, 1000);
-                } else {
-                    addLog(`예매 실패: ${data.message}`, 'error');
-                    set({ autoReserveActive: false });
-                    showAlert('❌ 예매 실패', data.message, '🚨');
+            // Connect to SSE for status updates
+            const API_BASE = localStorage.getItem('skimbleshanks_api_base') || 
+                            ((import.meta as any).env?.VITE_API_URL) || 
+                            (window.location.hostname === 'localhost' ? 'http://localhost:8000/api' : `${window.location.origin}/api`);
+            
+            const eventSource = new EventSource(`${API_BASE}/reserve/status/${task_id}`);
+            
+            eventSource.onmessage = (event) => {
+                const data = JSON.parse(event.data);
+                if (data.message) {
+                    addLog(data.message, data.type === 'error' ? 'error' : data.type === 'success' ? 'success' : 'info');
                 }
-            } catch (e: any) {
-                addLog(`오류 발생: ${e.message || '서버 연결 오류'}`, 'error');
-                autoTimer = setTimeout(attempt, 3000);
-            }
-        };
+                
+                if (data.type === 'info' && data.message.includes('회차')) {
+                    set(s => ({ autoReserveAttempts: s.autoReserveAttempts + 1 }));
+                }
 
-        attempt();
+                if (data.type === 'success') {
+                    showAlert('🎉 예매 성공!', data.message, '🎊');
+                    set({ autoReserveActive: false, activeTaskId: null });
+                    eventSource.close();
+                } else if (data.type === 'stop') {
+                    set({ autoReserveActive: false, activeTaskId: null });
+                    eventSource.close();
+                }
+            };
+
+            eventSource.onerror = () => {
+                addLog('실시간 상태 연결에 실패했습니다. (백그라운드에서 예매는 계속될 수 있습니다)', 'warning');
+                eventSource.close();
+            };
+
+        } catch (e: any) {
+            addLog(`예매 시작 실패: ${e.message}`, 'error');
+        }
     },
 
-    stopAutoReserve: () => {
+    stopAutoReserve: async () => {
+        const { activeTaskId } = get();
         const { addLog } = useLogStore.getState();
-        addLog('자동 예매를 중지합니다.', 'warning');
-        set({ autoReserveActive: false });
-        if (autoTimer) clearTimeout(autoTimer);
+        
+        if (activeTaskId) {
+            try {
+                await apiFetch(`/reserve/stop/${activeTaskId}`, { method: 'POST' });
+                addLog('예매 중지 요청을 보냈습니다.', 'warning');
+            } catch (e) {}
+        }
+        
+        set({ autoReserveActive: false, activeTaskId: null });
     }
 }));

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -10,6 +10,10 @@ from src.services.notifications import send_telegram
 from src.services import config_store, rail_service
 from src.services.logger import logger
 from src.adapters.rail import login_client, is_seat_available, SeatType
+import asyncio
+import uuid
+import json
+from fastapi.responses import StreamingResponse
 
 
 app = FastAPI(title="Skimbleshanks API")
@@ -44,6 +48,100 @@ async def verify_api_key(x_api_key: Optional[str] = Header(None)):
             detail={"code": "ERR_INVALID_API_KEY", "message": "Invalid or missing API Key"}
         )
     return x_api_key
+
+# --- Background Task Management ---
+class ReservationStatus:
+    def __init__(self):
+        self.queue = asyncio.Queue()
+        self.active = True
+        self.attempts = 0
+
+    async def push(self, data: dict):
+        await self.queue.put(data)
+
+RESERVATION_TASKS = {}
+
+async def run_reservation_loop(task_id: str, req: ReserveRequest):
+    status = RESERVATION_TASKS.get(task_id)
+    if not status: return
+
+    logger.info(f"Starting background reservation loop: {task_id}")
+    provider = req.provider
+    rail = None
+    
+    try:
+        while status.active:
+            status.attempts += 1
+            if status.attempts % 10 == 1 or not rail:
+                await status.push({"type": "info", "message": f"[{status.attempts}회차] 세션 확인 및 예매 시도..."})
+                rail = await _login(provider=provider)
+            else:
+                await status.push({"type": "info", "message": f"[{status.attempts}회차] 예매 시도 중..."})
+            
+            if not rail:
+                await status.push({"type": "error", "message": "로그인 세션 확보 실패. 10초 후 재시도합니다."})
+                await asyncio.sleep(10)
+                continue
+
+            passengers = rail_service.build_passengers(
+                req.adults, req.children, req.seniors, req.disability1to3, req.disability4to6
+            )
+
+            try:
+                trains = await run_in_threadpool(
+                    rail.search_train,
+                    dep=req.dep, arr=req.arr, date=req.date, time=req.time,
+                    passengers=passengers, available_only=False,
+                )
+
+                found = False
+                for target in req.targets:
+                    target_train = rail_service.find_target_train(trains, target.train_name)
+                    if not target_train: continue
+
+                    stype = rail_service.get_seat_type_enum(target.seat_type)
+                    if not stype: continue
+
+                    if is_seat_available(target_train, stype):
+                        found = True
+                        await status.push({"type": "info", "message": f"좌석 발견! {target.train_name} 예매 시도..."})
+                        reserve_info = await run_in_threadpool(rail.reserve, target_train, passengers=passengers, option=stype)
+                        
+                        msg = f"예매 성공! {reserve_info}"
+                        
+                        # Auto pay logic
+                        card_info = config_store.get_card_payment_info()
+                        if req.auto_pay and card_info and not getattr(reserve_info, 'is_waiting', False):
+                            paid = await run_in_threadpool(
+                                rail.pay_with_card, reserve_info, 
+                                card_info[0], card_info[1], card_info[2], card_info[3],
+                                0, "J" if len(card_info[2]) == 6 else "S"
+                            )
+                            if paid: msg += " (결제 완료)"
+
+                        await status.push({"type": "success", "message": msg})
+                        try: await run_in_threadpool(send_telegram, msg)
+                        except: pass
+                        
+                        status.active = False
+                        return
+
+                if not found:
+                    await asyncio.sleep(1.2) 
+                    
+            except Exception as e:
+                logger.error(f"Loop error in {task_id}: {e}")
+                # Reset rail on error to force re-login
+                rail = None
+                await status.push({"type": "error", "message": f"오류 발생: {str(e)} (세션 재설정)"})
+                await asyncio.sleep(3)
+
+    except Exception as e:
+        logger.exception(f"Fatal error in background task {task_id}")
+        await status.push({"type": "error", "message": "치명적 오류로 작업이 중단되었습니다."})
+    finally:
+        status.active = False
+        await status.push({"type": "stop", "message": "작업이 종료되었습니다."})
 
 class LoginRequest(BaseModel):
     user_id: str
@@ -324,6 +422,47 @@ async def reserve_train(req: ReserveRequest):
     except Exception as e:
         logger.exception("Reservation error")
         return {"success": False, "message": "An internal error occurred.", "retry": True}
+
+@app.post("/api/reserve/start", dependencies=[Depends(verify_api_key)])
+async def start_reserve(req: ReserveRequest):
+    task_id = str(uuid.uuid4())
+    status = ReservationStatus()
+    RESERVATION_TASKS[task_id] = status
+    
+    # Run in background without blocking
+    asyncio.create_task(run_reservation_loop(task_id, req))
+    
+    return {"task_id": task_id}
+
+@app.post("/api/reserve/stop/{task_id}", dependencies=[Depends(verify_api_key)])
+async def stop_reserve(task_id: str):
+    if task_id in RESERVATION_TASKS:
+        RESERVATION_TASKS[task_id].active = False
+        return {"message": "Stopping task..."}
+    raise HTTPException(status_code=404, detail="Task not found")
+
+@app.get("/api/reserve/status/{task_id}")
+async def reserve_status(task_id: str):
+    if task_id not in RESERVATION_TASKS:
+        raise HTTPException(status_code=404, detail="Task not found")
+    
+    status = RESERVATION_TASKS[task_id]
+
+    async def event_generator():
+        try:
+            while True:
+                data = await status.queue.get()
+                yield f"data: {json.dumps(data)}\n\n"
+                if data["type"] in ["success", "stop"]:
+                    break
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # Clean up task from memory if finished
+            if not status.active:
+                RESERVATION_TASKS.pop(task_id, None)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 # Serve frontend static files if they exist
 if os.path.exists("frontend/dist"):


### PR DESCRIPTION
이 PR은 이슈 #7과 #9를 해결합니다.
- 클라이언트 루프를 서버 백그라운드 작업(BackgroundTask)으로 이관
- SSE(Server-Sent Events)를 통한 실시간 예매 상태 스트리밍
- 세션 만료 시 자동 재로그인 로직(Self-healing) 구현